### PR TITLE
Fix to not remove all items when you're remove favorite item.

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -63,7 +63,7 @@ class Api {
 
     return compose(
       saveKey(KeyNames.favorites),
-      reject((favoriteId) => favoriteId !== id),
+      reject((favoriteId) => favoriteId === id),
       this.getFavorites,
     )();
   }


### PR DESCRIPTION
# Bug Fix

# Description
The following code:
```javascript
[1,2,3,4,5,6,7,8,9,0].map(x => {
  api.addFavorite(x);
  return x;
});
```
Store the next values in the local storage:
```javascript
Storage {favorites: "[1,2,3,4,5,6,7,8,9,0]", length: 1}
```

And when you use `api.removeFavorite`:
```javascript
api.removeFavorite(2)
```

Storing next values:
```javascript
Storage {favorites: "[2]", length: 1}
```

## Expected behavior
Stored values would be:
```javascript
Storage {favorites: "[1,3,4,5,6,7,8,9,0]", length: 1}
```
## Possible fix
Modify function `removeFavorite(id)`.
